### PR TITLE
Replaced return code from Failed to Success when cron file not changed

### DIFF
--- a/Services/CrontabInstaller.php
+++ b/Services/CrontabInstaller.php
@@ -77,7 +77,8 @@ class CrontabInstaller
         if ($changed) {
             return $this->executeInstall();
         }
-        return Command::FAILURE;
+
+        return Command::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
During deployment, if cron file not changed then the deployment process finishes with an error