### PR TITLE
* Added ability to update cron jobs file when rendered empty content …

### DIFF
--- a/Command/CrontabInstallCommand.php
+++ b/Command/CrontabInstallCommand.php
@@ -55,6 +55,10 @@ class CrontabInstallCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        return $this->crontabInstaller->install();
+        if (!$this->crontabInstaller->install()) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
     }
 }

--- a/Services/CrontabExecutor.php
+++ b/Services/CrontabExecutor.php
@@ -79,11 +79,6 @@ class CrontabExecutor
         $filename = $this->path . DIRECTORY_SEPARATOR . self::FILENAME;
 
         $renderedContent = $this->compiler->render();
-
-        if (!$renderedContent) {
-            return false;
-        }
-
         $actualContent = $this->finder->getContent($filename);
 
         if ($renderedContent === $actualContent) {

--- a/Services/CrontabInstaller.php
+++ b/Services/CrontabInstaller.php
@@ -12,7 +12,6 @@
 namespace Ecentria\Bundle\CrontabBundle\Services;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Command\Command;
 
 /**
  * Crontab installer
@@ -68,24 +67,25 @@ class CrontabInstaller
     /**
      * Install
      *
-     * @return int
+     * @return bool
      */
-    public function install(): int
+    public function install(): bool
     {
         $changed = $this->executor->dump();
 
         if ($changed) {
             return $this->executeInstall();
         }
-        return Command::FAILURE;
+
+        return true;
     }
 
     /**
      * Execute install
      *
-     * @return int
+     * @return bool
      */
-    private function executeInstall(): int
+    private function executeInstall(): bool
     {
         $this->validateUser();
 
@@ -102,11 +102,13 @@ class CrontabInstaller
                     'crontab' => file_get_contents($source)
                 ]
             );
-            return Command::SUCCESS;
+
+            return true;
         }
 
         $this->logger->error('New crontab was NOT installed');
-        return Command::FAILURE;
+
+        return false;
     }
 
     /**

--- a/Tests/Services/CrontabExecutorTest.php
+++ b/Tests/Services/CrontabExecutorTest.php
@@ -60,14 +60,15 @@ class CrontabExecutorTest extends WebTestCase
     /**
      * Test render with changes
      *
+     * @param string $actualContent
+     * @param string $renderedContent
+     *
      * @return void
+     * @dataProvider provideChangedContentData
      */
-    public function testRenderWithChanges()
+    public function testRenderWithChanges(string $actualContent, string $renderedContent)
     {
         $filename = 'foo' . DIRECTORY_SEPARATOR . CrontabExecutor::FILENAME;
-
-        $actualContent = 'foo';
-        $renderedContent = 'bar';
 
         $this->jobCompiler->expects($this->once())
             ->method('render')
@@ -113,5 +114,22 @@ class CrontabExecutorTest extends WebTestCase
             ->method('dumpFile');
 
         $this->assertFalse($this->executor->dump());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideChangedContentData(): array
+    {
+        return [
+            [
+                'actual_content'   => 'foo',
+                'rendered_content' => 'bar',
+            ],
+            [
+                'actual_content'   => 'foo',
+                'rendered_content' => '',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
* Added ability to update cron jobs file when rendered empty content and actual content not empty

How to reproduce
    1) Add jobs to cron config
    2) Execute ecentria:crontab:install
    3) Remove all jobs from config
    4) Execute ecentria:crontab:install

Expected Result: Cron file empty
Actual Result: Cron file not empty.